### PR TITLE
Automatic dependabot via* updates + update viabackwards to version 4.3.1 (1.12.2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    allow:
+      - depency-name: "com.viaversion:via*"
+        dependency-type: "direct"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: "weekly"
     allow:
       - depency-name: "com.viaversion:via*"
-        dependency-type: "direct"
+        dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - depency-name: "com.viaversion:via*"
+      - dependency-name: "com.viaversion:via*"
         dependency-type: "all"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ mod_base_package=de.enzaxd
 
 mixin_version=0.8.3
 
-viaversion_version=4.3.2-SNAPSHOT
-viabackwards_version=4.3.1-SNAPSHOT
+viaversion_version=4.4.0-1.19.1-rc3-SNAPSHOT
+viabackwards_version=4.4.0-1.19.1-rc3-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ mod_base_package=de.enzaxd
 
 mixin_version=0.8.3
 
-viaversion_version=4.4.0-1.19.1-rc3-SNAPSHOT
-viabackwards_version=4.4.0-1.19.1-rc3-SNAPSHOT
+viaversion_version=4.3.2-SNAPSHOT
+viabackwards_version=4.3.1


### PR DESCRIPTION
DependaBot will automatically check every week if the Via* version is the latest, if not, dependabot will do a pull request (For example "Update ViaVersion 4.3.2-SNAPSHOT --> 4.3.3)
(I hope this works properly, and that I've set it up correctly)
(plus this updates viabackwards to version 4.3.1)