### PR TITLE
Fix 1.8.9 ViaForge not compiling, Build Artifact name fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,5 +28,5 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.java == '8' }}
         uses: actions/upload-artifact@v2
         with:
-          name: ViaForge-1.12.2
+          name: ViaForge-1.8.9
           path: build/libs/

--- a/src/main/java/de/florianmichael/viaforge/ViaForge.java
+++ b/src/main/java/de/florianmichael/viaforge/ViaForge.java
@@ -11,7 +11,7 @@ public class ViaForge {
     public static void start() {
         ViaLoadingBase.ViaLoadingBaseBuilder.
                 create().
-                runDirectory(Minecraft.getMinecraft().gameDir).
+                runDirectory(Minecraft.getMinecraft().dataDir).
                 nativeVersion(RealmsSharedConstants.NETWORK_PROTOCOL_VERSION).
                 forceNativeVersionCondition(() -> Minecraft.getMinecraft().isSingleplayer()).
                 build();

--- a/src/main/java/de/florianmichael/viaforge/ViaForge.java
+++ b/src/main/java/de/florianmichael/viaforge/ViaForge.java
@@ -11,7 +11,7 @@ public class ViaForge {
     public static void start() {
         ViaLoadingBase.ViaLoadingBaseBuilder.
                 create().
-                runDirectory(Minecraft.getMinecraft().dataDir). // gameDir -> dataDir
+                runDirectory(Minecraft.getMinecraft().mcDataDir). // gameDir -> mcDataDir
                 nativeVersion(RealmsSharedConstants.NETWORK_PROTOCOL_VERSION).
                 forceNativeVersionCondition(() -> Minecraft.getMinecraft().isSingleplayer()).
                 build();

--- a/src/main/java/de/florianmichael/viaforge/ViaForge.java
+++ b/src/main/java/de/florianmichael/viaforge/ViaForge.java
@@ -11,7 +11,7 @@ public class ViaForge {
     public static void start() {
         ViaLoadingBase.ViaLoadingBaseBuilder.
                 create().
-                runDirectory(Minecraft.getMinecraft().dataDir).
+                runDirectory(Minecraft.getMinecraft().dataDir). // gameDir -> dataDir
                 nativeVersion(RealmsSharedConstants.NETWORK_PROTOCOL_VERSION).
                 forceNativeVersionCondition(() -> Minecraft.getMinecraft().isSingleplayer()).
                 build();


### PR DESCRIPTION
This pull request fixes 1.8.9 ViaForge not compiling, and changes the build artifact name, so it doesn't confuse everyone.